### PR TITLE
fix(pip): fix pip mode on firefox

### DIFF
--- a/src/pip.ts
+++ b/src/pip.ts
@@ -131,13 +131,12 @@ export async function openPiPWindow(context: NotePlacement): Promise<void> {
 
   const initialise = () => setupPiPWindow(targetWindow, context);
 
-  if (
-    targetWindow.document?.readyState === "complete" ||
-    targetWindow.document?.readyState === "interactive"
-  ) {
+  if (targetWindow.document?.readyState !== "loading") {
     initialise();
   } else {
-    targetWindow.addEventListener("load", initialise, { once: true });
+    targetWindow.addEventListener("load", initialise, {
+      once: true,
+    });
   }
 
   attachPiPLifecycle(targetWindow, () => {


### PR DESCRIPTION
#1 

### Solution

The problem is probably that if the window is completely empty ('uninitialized'), there is no document to speak of, so no document loading event can be triggered. 
We have a "chicken and egg" problem: the code that builds the page is waiting for an event that can only happen if the page already exists. 

The solution is to force initialization if the document is not actively being loaded. I'll modify the code to execute the 'initialize' function directly if 'readyState' is not 'loading'. This will cover Firefox's 'complete', 'interactive' and 'uninitialized' states.